### PR TITLE
fixed incorrectly assumed encapsulation by ctx object

### DIFF
--- a/skunkhash.c
+++ b/skunkhash.c
@@ -20,19 +20,22 @@ void Skunk_Hash(const char* input, char* output)
     //these uint512 in the c++ source of the client are backed by an array of uint32
     uint32_t hashA[16];
 
-    sph_skein512(&ctx.skein1, input, 80);
-    sph_skein512_close(&ctx.skein1, hashA);
+    sph_skein512_init(&ctx_skein);
+    sph_skein512(&ctx_skein, input, 80);
+    sph_skein512_close(&ctx_skein, hashA);
 
-    sph_cubehash512(&ctx.cubehash1, hashA, 64);
-    sph_cubehash512_close(&ctx.cubehash1, hashA);
+    sph_cubehash512_init(&ctx_cubehash);
+    sph_cubehash512(&ctx_cubehash, hashA, 64);
+    sph_cubehash512_close(&ctx_cubehash, hashA);
 
-    sph_fugue512(&ctx.fugue1, hashA, 64);
-    sph_fugue512_close(&ctx.fugue1, hashA);
-    
-    sph_gost512(&ctx.gost1, hashA, 64);
-    sph_gost512_close(&ctx.gost1, hashA);
+    sph_fugue512_init(&ctx_fugue);
+    sph_fugue512(&ctx_fugue, hashA, 64);
+    sph_fugue512_close(&ctx_fugue, hashA);
+   
+    sph_gost512_init(&ctx_gost);
+    sph_gost512(&ctx_gost, hashA, 64);
+    sph_gost512_close(&ctx_gost, hashA);
 
     memcpy(output, hashA, 32);
-
 }
 


### PR DESCRIPTION
Fixed bug relating to "&ctx.skein1" not being defined. skein1 is not a member object of generic ctx object.  The same bug exists for 4 hash functions. 

Module will now compile and work.